### PR TITLE
chore: Added Page State Store

### DIFF
--- a/src/stores/pageState.ts
+++ b/src/stores/pageState.ts
@@ -1,0 +1,17 @@
+import { writable } from "svelte/store";
+
+export interface IPageState {
+  AllBooks: {
+    offset: number;
+    limit: number;
+  };
+}
+
+export const pageState = writable<IPageState>({
+  AllBooks: {
+    offset: 0,
+    limit: 5,
+  },
+});
+
+export default pageState;


### PR DESCRIPTION
Store page state in writable store `pageState`

This was done as a fix to #3, because it's a better option than passing around query params (need to parse, validate, and would only work if the user uses the custom back button, so we can pass the params back to the homepage. Repeat this for all new pages that need similar functionality)

`pageState.ts` contains:

- an interface, `IPageState`, to have types in components when using the store.
- `pageState`, a writable store with the initial values

All of them are exported in case we need to use them somewhere else